### PR TITLE
Hardware acceleration for Silicon Labs devices

### DIFF
--- a/include/psa/crypto_driver_contexts_composites.h
+++ b/include/psa/crypto_driver_contexts_composites.h
@@ -43,6 +43,10 @@
 #endif
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+#include "sli_cryptoacc_transparent_types.h"
+#endif
+
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
 #include <libtestdriver1/include/psa/crypto.h>
 #endif
@@ -140,6 +144,9 @@ typedef union {
     sli_se_opaque_mac_operation_t sli_se_opaque_ctx;
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE  && SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    sli_cryptoacc_transparent_mac_operation_t sli_cryptoacc_transparent_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 } psa_driver_mac_context_t;
 
 typedef union {
@@ -157,6 +164,9 @@ typedef union {
     sli_se_opaque_aead_operation_t sli_se_opaque_ctx;
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE  && SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    sli_cryptoacc_transparent_aead_operation_t sli_cryptoacc_transparent_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 } psa_driver_aead_context_t;
 
 typedef union {

--- a/include/psa/crypto_driver_contexts_composites.h
+++ b/include/psa/crypto_driver_contexts_composites.h
@@ -34,6 +34,15 @@
 #include "cc3xx_crypto_primitives_private.h"
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+#include "sli_psa_driver_features.h"
+#include "sli_se_transparent_types.h"
+
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+#include "sli_se_opaque_types.h"
+#endif
+#endif
+
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
 #include <libtestdriver1/include/psa/crypto.h>
 #endif
@@ -125,6 +134,12 @@ typedef union {
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
     cc3xx_mac_operation_t cc3xx_driver_ctx;
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    sli_se_transparent_mac_operation_t sli_se_transparent_ctx;
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+    sli_se_opaque_mac_operation_t sli_se_opaque_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE  && SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 } psa_driver_mac_context_t;
 
 typedef union {
@@ -136,6 +151,12 @@ typedef union {
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
     cc3xx_aead_operation_t cc3xx_driver_ctx;
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    sli_se_transparent_aead_operation_t sli_se_transparent_ctx;
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+    sli_se_opaque_aead_operation_t sli_se_opaque_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE  && SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 } psa_driver_aead_context_t;
 
 typedef union {

--- a/include/psa/crypto_driver_contexts_primitives.h
+++ b/include/psa/crypto_driver_contexts_primitives.h
@@ -42,6 +42,10 @@
 #endif
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+#include "sli_cryptoacc_transparent_types.h"
+#endif
+
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
 #include <libtestdriver1/include/psa/crypto.h>
 #endif
@@ -109,6 +113,9 @@ typedef union {
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
     sli_se_transparent_hash_operation_t sli_se_transparent_ctx;
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    sli_cryptoacc_transparent_hash_operation_t sli_cryptoacc_transparent_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 } psa_driver_hash_context_t;
 
 typedef union {
@@ -127,6 +134,9 @@ typedef union {
     sli_se_opaque_cipher_operation_t sli_se_opaque_ctx;
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE  && SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    sli_cryptoacc_transparent_cipher_operation_t sli_cryptoacc_transparent_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 } psa_driver_cipher_context_t;
 
 #endif /* PSA_CRYPTO_DRIVER_CONTEXTS_PRIMITIVES_H */

--- a/include/psa/crypto_driver_contexts_primitives.h
+++ b/include/psa/crypto_driver_contexts_primitives.h
@@ -33,6 +33,15 @@
 #include "cc3xx_crypto_primitives_private.h"
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+#include "sli_psa_driver_features.h"
+#include "sli_se_transparent_types.h"
+
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+#include "sli_se_opaque_types.h"
+#endif
+#endif
+
 #if defined(MBEDTLS_TEST_LIBTESTDRIVER1)
 #include <libtestdriver1/include/psa/crypto.h>
 #endif
@@ -97,6 +106,9 @@ typedef union {
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
     cc3xx_hash_operation_t cc3xx_driver_ctx;
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    sli_se_transparent_hash_operation_t sli_se_transparent_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 } psa_driver_hash_context_t;
 
 typedef union {
@@ -109,6 +121,12 @@ typedef union {
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
     cc3xx_cipher_operation_t cc3xx_driver_ctx;
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    sli_se_transparent_cipher_operation_t sli_se_transparent_ctx;
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+    sli_se_opaque_cipher_operation_t sli_se_opaque_ctx;
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE  && SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 } psa_driver_cipher_context_t;
 
 #endif /* PSA_CRYPTO_DRIVER_CONTEXTS_PRIMITIVES_H */

--- a/library/psa_crypto.c
+++ b/library/psa_crypto.c
@@ -7655,7 +7655,7 @@ psa_status_t psa_key_derivation_key_agreement(psa_key_derivation_operation_t *op
     if (!PSA_ALG_IS_KEY_AGREEMENT(operation->alg)) {
         return PSA_ERROR_INVALID_ARGUMENT;
     }
-    status = psa_get_and_lock_transparent_key_slot_with_policy(
+    status = psa_get_and_lock_key_slot_with_policy(
         private_key, &slot, PSA_KEY_USAGE_DERIVE, operation->alg);
     if (status != PSA_SUCCESS) {
         return status;
@@ -7705,7 +7705,7 @@ psa_status_t psa_raw_key_agreement(psa_algorithm_t alg,
         status = PSA_ERROR_INVALID_ARGUMENT;
         goto exit;
     }
-    status = psa_get_and_lock_transparent_key_slot_with_policy(
+    status = psa_get_and_lock_key_slot_with_policy(
         private_key, &slot, PSA_KEY_USAGE_DERIVE, alg);
     if (status != PSA_SUCCESS) {
         goto exit;

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -76,6 +76,19 @@
 #endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#endif
+#include "sli_psa_driver_features.h"
+#include "sli_cryptoacc_transparent_types.h"
+#include "sli_cryptoacc_transparent_functions.h"
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+#include "sli_cryptoacc_opaque_types.h"
+#include "sli_cryptoacc_opaque_functions.h"
+#endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
+
 /* END-driver headers */
 
 /* Auto-generated values depending on which drivers are registered.
@@ -99,6 +112,9 @@ enum {
     PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID,
 #endif
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID,
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 };
 
 /* END-driver id */
@@ -158,6 +174,12 @@ static inline psa_status_t psa_driver_wrapper_init( void )
     if( status != PSA_SUCCESS )
         return( status );
 #endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    status = sli_cryptoacc_transparent_driver_init();
+    if( status != PSA_SUCCESS )
+        return( status );
 #endif
 
     (void) status;
@@ -490,6 +512,20 @@ static inline psa_status_t psa_driver_wrapper_sign_hash(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_sign_hash( attributes,
+                                                          key_buffer,
+                                                          key_buffer_size,
+                                                          alg,
+                                                          hash,
+                                                          hash_length,
+                                                          signature,
+                                                          signature_size,
+                                                          signature_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 #if defined (MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_ECDSA(alg) &&
@@ -635,6 +671,19 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_verify_hash( attributes,
+                                                            key_buffer,
+                                                            key_buffer_size,
+                                                            alg,
+                                                            hash,
+                                                            hash_length,
+                                                            signature,
+                                                            signature_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 #if defined (MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_ECDSA(alg) &&
@@ -1061,6 +1110,15 @@ static inline psa_status_t psa_driver_wrapper_generate_key(
                 if( status != PSA_ERROR_NOT_SUPPORTED )
                     break;
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+                status = sli_cryptoacc_transparent_generate_key( attributes,
+                                                                 key_buffer,
+                                                                 key_buffer_size,
+                                                                 key_buffer_length );
+                /* Declared with fallback == true */
+                if( status != PSA_ERROR_NOT_SUPPORTED )
+                    break;
+#endif
 #if defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED)
                 if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                     psa_get_key_type(attributes) == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1) &&
@@ -1177,6 +1235,18 @@ static inline psa_status_t psa_driver_wrapper_import_key(
                                 bits
             );
 
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_import_key( attributes,
+                                                           data, data_length,
+                                                           key_buffer,
+                                                           key_buffer_size,
+                                                           key_buffer_length,
+                                                           bits );
+            /* Declared with fallback == true */
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
@@ -1464,6 +1534,22 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_cipher_encrypt(
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg,
+                        iv,
+                        iv_length,
+                        input,
+                        input_length,
+                        output,
+                        output_size,
+                        output_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -1596,6 +1682,20 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_cipher_decrypt(
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg,
+                        input,
+                        input_length,
+                        output,
+                        output_size,
+                        output_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -1711,6 +1811,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_cipher_encrypt_setup(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1821,6 +1933,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_cipher_decrypt_setup(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1914,6 +2038,12 @@ static inline psa_status_t psa_driver_wrapper_cipher_set_iv(
                         &operation->ctx.sli_se_transparent_ctx,
                         iv, iv_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_cipher_set_iv(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        iv, iv_length ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_cipher_set_iv(
@@ -1977,6 +2107,13 @@ static inline psa_status_t psa_driver_wrapper_cipher_update(
                         input, input_length,
                         output, output_size, output_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_cipher_update(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        input, input_length,
+                        output, output_size, output_length ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_cipher_update(
@@ -2034,6 +2171,12 @@ static inline psa_status_t psa_driver_wrapper_cipher_finish(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_cipher_finish(
                         &operation->ctx.sli_se_transparent_ctx,
+                        output, output_size, output_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_cipher_finish(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
                         output, output_size, output_length ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
@@ -2096,6 +2239,11 @@ static inline psa_status_t psa_driver_wrapper_cipher_abort(
             return( sli_se_transparent_cipher_abort(
                         &operation->ctx.sli_se_transparent_ctx ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_cipher_abort(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_cipher_abort(
@@ -2136,6 +2284,12 @@ static inline psa_status_t psa_driver_wrapper_hash_compute(
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
     status = sli_se_transparent_hash_compute(
+                alg, input, input_length, hash, hash_size, hash_length );
+    if( status != PSA_ERROR_NOT_SUPPORTED )
+        return( status );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    status = sli_cryptoacc_transparent_hash_compute(
                 alg, input, input_length, hash, hash_size, hash_length );
     if( status != PSA_ERROR_NOT_SUPPORTED )
         return( status );
@@ -2187,6 +2341,15 @@ static inline psa_status_t psa_driver_wrapper_hash_setup(
                 &operation->ctx.sli_se_transparent_ctx, alg );
     if( status == PSA_SUCCESS )
         operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+
+    if( status != PSA_ERROR_NOT_SUPPORTED )
+        return( status );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    status = sli_cryptoacc_transparent_hash_setup(
+                &operation->ctx.sli_cryptoacc_transparent_ctx, alg );
+    if( status == PSA_SUCCESS )
+        operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
 
     if( status != PSA_ERROR_NOT_SUPPORTED )
         return( status );
@@ -2244,6 +2407,13 @@ static inline psa_status_t psa_driver_wrapper_hash_clone(
                         &source_operation->ctx.sli_se_transparent_ctx,
                         &target_operation->ctx.sli_se_transparent_ctx ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            target_operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
+            return( sli_cryptoacc_transparent_hash_clone(
+                        &source_operation->ctx.sli_cryptoacc_transparent_ctx,
+                        &target_operation->ctx.sli_cryptoacc_transparent_ctx ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) target_operation;
@@ -2280,6 +2450,12 @@ static inline psa_status_t psa_driver_wrapper_hash_update(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_hash_update(
                         &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_hash_update(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
                         input, input_length ) );
 #endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
@@ -2322,6 +2498,12 @@ static inline psa_status_t psa_driver_wrapper_hash_finish(
                         &operation->ctx.sli_se_transparent_ctx,
                         hash, hash_size, hash_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_hash_finish(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        hash, hash_size, hash_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) hash;
@@ -2355,6 +2537,11 @@ static inline psa_status_t psa_driver_wrapper_hash_abort(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_hash_abort(
                         &operation->ctx.sli_se_transparent_ctx ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_hash_abort(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx ) );
 #endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
@@ -2410,6 +2597,17 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt(
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
             status = sli_se_transparent_aead_encrypt(
+                        attributes, key_buffer, key_buffer_size,
+                        alg,
+                        nonce, nonce_length,
+                        additional_data, additional_data_length,
+                        plaintext, plaintext_length,
+                        ciphertext, ciphertext_size, ciphertext_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_aead_encrypt(
                         attributes, key_buffer, key_buffer_size,
                         alg,
                         nonce, nonce_length,
@@ -2506,6 +2704,17 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_aead_decrypt(
+                        attributes, key_buffer, key_buffer_size,
+                        alg,
+                        nonce, nonce_length,
+                        additional_data, additional_data_length,
+                        ciphertext, ciphertext_length,
+                        plaintext, plaintext_size, plaintext_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2580,6 +2789,15 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt_setup(
             operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
             status = sli_se_transparent_aead_encrypt_setup(
                         &operation->ctx.sli_se_transparent_ctx,
+                        attributes, key_buffer, key_buffer_size,
+                        alg );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
+            status = sli_cryptoacc_transparent_aead_encrypt_setup(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
                         attributes, key_buffer, key_buffer_size,
                         alg );
             if( status != PSA_ERROR_NOT_SUPPORTED )
@@ -2666,6 +2884,15 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
+            status = sli_cryptoacc_transparent_aead_decrypt_setup(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        attributes, key_buffer, key_buffer_size,
+                        alg );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2734,6 +2961,12 @@ static inline psa_status_t psa_driver_wrapper_aead_set_nonce(
                         &operation->ctx.sli_se_transparent_ctx,
                         nonce, nonce_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_aead_set_nonce(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        nonce, nonce_length ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_aead_set_nonce(
@@ -2786,6 +3019,12 @@ static inline psa_status_t psa_driver_wrapper_aead_set_lengths(
                         &operation->ctx.sli_se_transparent_ctx,
                         ad_length, plaintext_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_aead_set_lengths(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        ad_length, plaintext_length ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_aead_set_lengths(
@@ -2836,6 +3075,12 @@ static inline psa_status_t psa_driver_wrapper_aead_update_ad(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_aead_update_ad(
                         &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_aead_update_ad(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
                         input, input_length ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
@@ -2894,6 +3139,13 @@ static inline psa_status_t psa_driver_wrapper_aead_update(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_aead_update(
                         &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length, output, output_size,
+                        output_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_aead_update(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
                         input, input_length, output, output_size,
                         output_length ) );
 #endif
@@ -2959,6 +3211,13 @@ static inline psa_status_t psa_driver_wrapper_aead_finish(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_aead_finish(
                         &operation->ctx.sli_se_transparent_ctx,
+                        ciphertext, ciphertext_size,
+                        ciphertext_length, tag, tag_size, tag_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_aead_finish(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
                         ciphertext, ciphertext_size,
                         ciphertext_length, tag, tag_size, tag_length ) );
 #endif
@@ -3047,6 +3306,13 @@ static inline psa_status_t psa_driver_wrapper_aead_verify(
                         plaintext, plaintext_size,
                         plaintext_length, tag, tag_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_aead_verify(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        plaintext, plaintext_size,
+                        plaintext_length, tag, tag_length ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_aead_verify(
@@ -3095,6 +3361,11 @@ static inline psa_status_t psa_driver_wrapper_aead_abort(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_aead_abort(
                         &operation->ctx.sli_se_transparent_ctx ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_aead_abort(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
@@ -3157,6 +3428,14 @@ static inline psa_status_t psa_driver_wrapper_mac_compute(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_mac_compute(
+                        attributes, key_buffer, key_buffer_size, alg,
+                        input, input_length,
+                        mac, mac_size, mac_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -3182,6 +3461,13 @@ static inline psa_status_t psa_driver_wrapper_mac_compute(
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
             return ( sli_se_opaque_mac_compute(
+                        attributes, key_buffer, key_buffer_size, alg,
+                        input, input_length,
+                        mac, mac_size, mac_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SL_CRYPTOACC_OPAQUE:
+            return ( sli_cryptoacc_opaque_mac_compute(
                         attributes, key_buffer, key_buffer_size, alg,
                         input, input_length,
                         mac, mac_size, mac_length ) );
@@ -3253,6 +3539,19 @@ static inline psa_status_t psa_driver_wrapper_mac_sign_setup(
             /* Declared with fallback == true */
             if( status == PSA_SUCCESS )
                 operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_mac_sign_setup(
+                &operation->ctx.sli_cryptoacc_transparent_ctx,
+                attributes,
+                key_buffer, key_buffer_size,
+                alg );
+            /* Declared with fallback == true */
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
 
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
@@ -3365,6 +3664,19 @@ static inline psa_status_t psa_driver_wrapper_mac_verify_setup(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_mac_verify_setup(
+                &operation->ctx.sli_cryptoacc_transparent_ctx,
+                attributes,
+                key_buffer, key_buffer_size,
+                alg );
+            /* Declared with fallback == true */
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID;
+
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -3453,6 +3765,12 @@ static inline psa_status_t psa_driver_wrapper_mac_update(
                         &operation->ctx.sli_se_transparent_ctx,
                         input, input_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_mac_update(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        input, input_length ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_mac_update(
@@ -3502,6 +3820,12 @@ static inline psa_status_t psa_driver_wrapper_mac_sign_finish(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_mac_sign_finish(
                         &operation->ctx.sli_se_transparent_ctx,
+                        mac, mac_size, mac_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_mac_sign_finish(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
                         mac, mac_size, mac_length ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
@@ -3556,6 +3880,12 @@ static inline psa_status_t psa_driver_wrapper_mac_verify_finish(
                         &operation->ctx.sli_se_transparent_ctx,
                         mac, mac_length ) );
 #endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_mac_verify_finish(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx,
+                        mac, mac_length ) );
+#endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
             return( sli_se_opaque_mac_verify_finish(
@@ -3597,6 +3927,11 @@ static inline psa_status_t psa_driver_wrapper_mac_abort(
         case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
             return( sli_se_transparent_mac_abort(
                         &operation->ctx.sli_se_transparent_ctx ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+        case PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID:
+            return( sli_cryptoacc_transparent_mac_abort(
+                        &operation->ctx.sli_cryptoacc_transparent_ctx ) );
 #endif
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
         case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
@@ -3818,6 +4153,20 @@ static inline psa_status_t psa_driver_wrapper_key_agreement(
                                                        shared_secret,
                                                        shared_secret_size,
                                                        shared_secret_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_key_agreement( alg,
+                                                              attributes,
+                                                              key_buffer,
+                                                              key_buffer_size,
+                                                              peer_key,
+                                                              peer_key_length,
+                                                              shared_secret,
+                                                              shared_secret_size,
+                                                              shared_secret_length );
             /* Declared with fallback == true */
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );

--- a/library/psa_crypto_driver_wrappers.h
+++ b/library/psa_crypto_driver_wrappers.h
@@ -63,6 +63,19 @@
 #include "cc3xx.h"
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#endif
+#include "sli_psa_driver_features.h"
+#include "sli_se_transparent_types.h"
+#include "sli_se_transparent_functions.h"
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+#include "sli_se_opaque_types.h"
+#include "sli_se_opaque_functions.h"
+#endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+
 /* END-driver headers */
 
 /* Auto-generated values depending on which drivers are registered.
@@ -80,6 +93,12 @@ enum {
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
     PSA_CRYPTO_CC3XX_DRIVER_ID,
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID,
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+    PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID,
+#endif
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 };
 
 /* END-driver id */
@@ -128,6 +147,17 @@ static inline psa_status_t psa_driver_wrapper_init( void )
     status = cc3xx_init();
     if (status != PSA_SUCCESS)
         return ( status );
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    status = sli_se_transparent_driver_init();
+    if( status != PSA_SUCCESS )
+        return( status );
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+    status = sli_se_opaque_driver_init();
+    if( status != PSA_SUCCESS )
+        return( status );
+#endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
 #endif
 
     (void) status;
@@ -205,6 +235,20 @@ static inline psa_status_t psa_driver_wrapper_sign_message(
                         signature_length );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_sign_message( attributes,
+                                                      key_buffer,
+                                                      key_buffer_size,
+                                                      alg,
+                                                      input,
+                                                      input_length,
+                                                      signature,
+                                                      signature_size,
+                                                      signature_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
             return( psa_sign_message_builtin( attributes,
                                               key_buffer,
@@ -235,6 +279,20 @@ static inline psa_status_t psa_driver_wrapper_sign_message(
                 return( status );
             break;
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_sign_message( attributes,
+                                                 key_buffer,
+                                                 key_buffer_size,
+                                                 alg,
+                                                 input,
+                                                 input_length,
+                                                 signature,
+                                                 signature_size,
+                                                 signature_length );
+            /* No fallback for opaque */
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -292,6 +350,19 @@ static inline psa_status_t psa_driver_wrapper_verify_message(
                         signature_length );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_verify_message( attributes,
+                                                        key_buffer,
+                                                        key_buffer_size,
+                                                        alg,
+                                                        input,
+                                                        input_length,
+                                                        signature,
+                                                        signature_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
             return( psa_verify_message_builtin( attributes,
                                                 key_buffer,
@@ -319,6 +390,19 @@ static inline psa_status_t psa_driver_wrapper_verify_message(
                 return( status );
             break;
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_verify_message( attributes,
+                                                   key_buffer,
+                                                   key_buffer_size,
+                                                   alg,
+                                                   input,
+                                                   input_length,
+                                                   signature,
+                                                   signature_length );
+            /* No fallback for opaque */
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -392,6 +476,20 @@ static inline psa_status_t psa_driver_wrapper_sign_hash(
                                       signature_length );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_sign_hash( attributes,
+                                                   key_buffer,
+                                                   key_buffer_size,
+                                                   alg,
+                                                   hash,
+                                                   hash_length,
+                                                   signature,
+                                                   signature_size,
+                                                   signature_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 #if defined (MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_ECDSA(alg) &&
@@ -438,6 +536,20 @@ static inline psa_status_t psa_driver_wrapper_sign_hash(
                                                              signature_size,
                                                              signature_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_sign_hash( attributes,
+                                              key_buffer,
+                                              key_buffer_size,
+                                              alg,
+                                              hash,
+                                              hash_length,
+                                              signature,
+                                              signature_size,
+                                              signature_length );
+            /* No fallback for opaque */
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -510,6 +622,19 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
                                         signature_length );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_verify_hash( attributes,
+                                                     key_buffer,
+                                                     key_buffer_size,
+                                                     alg,
+                                                     hash,
+                                                     hash_length,
+                                                     signature,
+                                                     signature_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 #if defined (MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_ECDSA(alg) &&
@@ -553,6 +678,19 @@ static inline psa_status_t psa_driver_wrapper_verify_hash(
                                                                signature,
                                                                signature_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_verify_hash( attributes,
+                                                key_buffer,
+                                                key_buffer_size,
+                                                alg,
+                                                hash,
+                                                hash_length,
+                                                signature,
+                                                signature_length );
+            /* No fallback for opaque */
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -827,6 +965,11 @@ static inline psa_status_t psa_driver_wrapper_get_key_buffer_size_from_key_data(
             return( ( *key_buffer_size != 0 ) ?
                     PSA_SUCCESS : PSA_ERROR_NOT_SUPPORTED );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            *key_buffer_size = data_length;
+            return( psa_driver_wrapper_get_key_buffer_size( attributes, key_buffer_size ) );
+#endif
 
         default:
             (void)key_type;
@@ -909,6 +1052,15 @@ static inline psa_status_t psa_driver_wrapper_generate_key(
                     key_buffer_length );
                 break;
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+                status = sli_se_transparent_generate_key( attributes,
+                                                          key_buffer,
+                                                          key_buffer_size,
+                                                          key_buffer_length );
+                /* Declared with fallback == true */
+                if( status != PSA_ERROR_NOT_SUPPORTED )
+                    break;
+#endif
 #if defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED)
                 if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                     psa_get_key_type(attributes) == PSA_KEY_TYPE_ECC_KEY_PAIR(PSA_ECC_FAMILY_SECP_R1) &&
@@ -940,6 +1092,16 @@ static inline psa_status_t psa_driver_wrapper_generate_key(
                 attributes, key_buffer, key_buffer_size, key_buffer_length );
             break;
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            // Call opaque driver API
+            status = sli_se_opaque_generate_key( attributes,
+                                                 key_buffer,
+                                                 key_buffer_size,
+                                                 key_buffer_length );
+            /* No fallback for opaque drivers */
+            return status;
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
         default:
@@ -1019,6 +1181,18 @@ static inline psa_status_t psa_driver_wrapper_import_key(
                 return( status );
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_import_key( attributes,
+                                                    data, data_length,
+                                                    key_buffer,
+                                                    key_buffer_size,
+                                                    key_buffer_length,
+                                                    bits );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
+
 #if (defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED) )
             status = p256_transparent_import_key
                 (attributes,
@@ -1058,6 +1232,14 @@ static inline psa_status_t psa_driver_wrapper_import_key(
         ));
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_WRAPPED_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return( sli_se_opaque_import_key(
+                         attributes,
+                         data, data_length,
+                         key_buffer, key_buffer_size,
+                         key_buffer_length, bits ) );
+#endif
 
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
@@ -1126,6 +1308,16 @@ static inline psa_status_t psa_driver_wrapper_export_key(
         ));
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_WRAPPED_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            // We are on a vault device, call opaque driver
+            return( sli_se_opaque_export_key( attributes,
+                                              key_buffer,
+                                              key_buffer_size,
+                                              data,
+                                              data_size,
+                                              data_length ) );
+#endif
 
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
@@ -1173,6 +1365,16 @@ static inline psa_status_t psa_driver_wrapper_copy_key(
         ));
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) \
+    && defined(SLI_PSA_DRIVER_FEATURE_WRAPPED_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+          return sli_se_opaque_copy_key(attributes,
+                                        source_key,
+                                        source_key_length,
+                                        target_key_buffer,
+                                        target_key_buffer_size,
+                                        target_key_buffer_length);
+#endif
 
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
@@ -1246,6 +1448,22 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt(
                                            output_length );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_cipher_encrypt(
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg,
+                        iv,
+                        iv_length,
+                        input,
+                        input_length,
+                        output,
+                        output_size,
+                        output_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -1280,6 +1498,21 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt(
                                                         output_size,
                                                         output_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return ( sli_se_opaque_cipher_encrypt(
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg,
+                        iv,
+                        iv_length,
+                        input,
+                        input_length,
+                        output,
+                        output_size,
+                        output_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
         default:
@@ -1349,6 +1582,20 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt(
                                            output_length );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_cipher_decrypt(
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg,
+                        input,
+                        input_length,
+                        output,
+                        output_size,
+                        output_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
@@ -1379,6 +1626,19 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt(
                                                         output_size,
                                                         output_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return ( sli_se_opaque_cipher_decrypt(
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg,
+                        input,
+                        input_length,
+                        output,
+                        output_size,
+                        output_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
         default:
@@ -1439,6 +1699,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt_setup(
             operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_cipher_encrypt_setup(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1470,6 +1742,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_encrypt_setup(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_cipher_encrypt_setup(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID;
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -1525,6 +1809,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt_setup(
             operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_cipher_decrypt_setup(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_CIPHER)
             /* Fell through, meaning no accelerator supports this operation */
@@ -1556,6 +1852,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_decrypt_setup(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_cipher_decrypt_setup(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        attributes,
+                        key_buffer,
+                        key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID;
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -1600,6 +1908,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_set_iv(
                         &operation->ctx.cc3xx_driver_ctx,
                         iv, iv_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_cipher_set_iv(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        iv, iv_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_cipher_set_iv(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        iv, iv_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1650,6 +1970,20 @@ static inline psa_status_t psa_driver_wrapper_cipher_update(
                         input, input_length,
                         output, output_size, output_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_cipher_update(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length,
+                        output, output_size, output_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_cipher_update(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        input, input_length,
+                        output, output_size, output_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1696,6 +2030,18 @@ static inline psa_status_t psa_driver_wrapper_cipher_finish(
                         &operation->ctx.cc3xx_driver_ctx,
                         output, output_size, output_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX*/
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_cipher_finish(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        output, output_size, output_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_cipher_finish(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        output, output_size, output_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1745,6 +2091,16 @@ static inline psa_status_t psa_driver_wrapper_cipher_abort(
                 sizeof( operation->ctx.cc3xx_driver_ctx ) );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_cipher_abort(
+                        &operation->ctx.sli_se_transparent_ctx ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_cipher_abort(
+                        &operation->ctx.sli_se_opaque_ctx ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -1778,6 +2134,12 @@ static inline psa_status_t psa_driver_wrapper_hash_compute(
             hash_length);
     return status;
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    status = sli_se_transparent_hash_compute(
+                alg, input, input_length, hash, hash_size, hash_length );
+    if( status != PSA_ERROR_NOT_SUPPORTED )
+        return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
     /* If software fallback is compiled in, try fallback */
@@ -1820,6 +2182,15 @@ static inline psa_status_t psa_driver_wrapper_hash_setup(
     operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
     return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    status = sli_se_transparent_hash_setup(
+                &operation->ctx.sli_se_transparent_ctx, alg );
+    if( status == PSA_SUCCESS )
+        operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+
+    if( status != PSA_ERROR_NOT_SUPPORTED )
+        return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
     /* If software fallback is compiled in, try fallback */
@@ -1866,6 +2237,13 @@ static inline psa_status_t psa_driver_wrapper_hash_clone(
                         &target_operation->ctx.cc3xx_driver_ctx ) );
 
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            target_operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+            return( sli_se_transparent_hash_clone(
+                        &source_operation->ctx.sli_se_transparent_ctx,
+                        &target_operation->ctx.sli_se_transparent_ctx ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) target_operation;
@@ -1898,6 +2276,12 @@ static inline psa_status_t psa_driver_wrapper_hash_update(
                         &operation->ctx.cc3xx_driver_ctx,
                         input, input_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_hash_update(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) input;
@@ -1932,6 +2316,12 @@ static inline psa_status_t psa_driver_wrapper_hash_finish(
                         &operation->ctx.cc3xx_driver_ctx,
                         hash, hash_size, hash_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_hash_finish(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        hash, hash_size, hash_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) hash;
@@ -1961,6 +2351,11 @@ static inline psa_status_t psa_driver_wrapper_hash_abort(
             return( cc3xx_hash_abort(
                         &operation->ctx.cc3xx_driver_ctx ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_hash_abort(
+                        &operation->ctx.sli_se_transparent_ctx ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             return( PSA_ERROR_BAD_STATE );
@@ -2013,6 +2408,17 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_aead_encrypt(
+                        attributes, key_buffer, key_buffer_size,
+                        alg,
+                        nonce, nonce_length,
+                        additional_data, additional_data_length,
+                        plaintext, plaintext_length,
+                        ciphertext, ciphertext_size, ciphertext_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2025,6 +2431,16 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt(
                         ciphertext, ciphertext_size, ciphertext_length ) );
 
         /* Add cases for opaque driver here */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return ( sli_se_opaque_aead_encrypt(
+                        attributes, key_buffer, key_buffer_size,
+                        alg,
+                        nonce, nonce_length,
+                        additional_data, additional_data_length,
+                        plaintext, plaintext_length,
+                        ciphertext, ciphertext_size, ciphertext_length ) );
+#endif
 
         default:
             /* Key is declared with a lifetime not known to us */
@@ -2079,6 +2495,17 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_aead_decrypt(
+                        attributes, key_buffer, key_buffer_size,
+                        alg,
+                        nonce, nonce_length,
+                        additional_data, additional_data_length,
+                        ciphertext, ciphertext_length,
+                        plaintext, plaintext_size, plaintext_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2091,6 +2518,16 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt(
                         plaintext, plaintext_size, plaintext_length ) );
 
         /* Add cases for opaque driver here */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return ( sli_se_opaque_aead_decrypt(
+                        attributes, key_buffer, key_buffer_size,
+                        alg,
+                        nonce, nonce_length,
+                        additional_data, additional_data_length,
+                        ciphertext, ciphertext_length,
+                        plaintext, plaintext_size, plaintext_length ) );
+#endif
 
         default:
             /* Key is declared with a lifetime not known to us */
@@ -2139,6 +2576,15 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt_setup(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+            status = sli_se_transparent_aead_encrypt_setup(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        attributes, key_buffer, key_buffer_size,
+                        alg );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2151,6 +2597,16 @@ static inline psa_status_t psa_driver_wrapper_aead_encrypt_setup(
             return( status );
 
         /* Add cases for opaque driver here */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_aead_encrypt_setup(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        attributes, key_buffer, key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID;
+            return( status );
+#endif
 
         default:
             /* Key is declared with a lifetime not known to us */
@@ -2201,6 +2657,15 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt_setup(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+            status = sli_se_transparent_aead_decrypt_setup(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        attributes, key_buffer, key_buffer_size,
+                        alg );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
             /* Fell through, meaning no accelerator supports this operation */
@@ -2214,6 +2679,16 @@ static inline psa_status_t psa_driver_wrapper_aead_decrypt_setup(
             return( status );
 
         /* Add cases for opaque driver here */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_aead_decrypt_setup(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        attributes, key_buffer, key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID;
+            return( status );
+#endif
 
         default:
             /* Key is declared with a lifetime not known to us */
@@ -2253,6 +2728,18 @@ static inline psa_status_t psa_driver_wrapper_aead_set_nonce(
                         &operation->ctx.cc3xx_driver_ctx,
                         nonce, nonce_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_aead_set_nonce(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        nonce, nonce_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_aead_set_nonce(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        nonce, nonce_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -2293,6 +2780,18 @@ static inline psa_status_t psa_driver_wrapper_aead_set_lengths(
                     &operation->ctx.cc3xx_driver_ctx,
                     ad_length, plaintext_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_aead_set_lengths(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        ad_length, plaintext_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_aead_set_lengths(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        ad_length, plaintext_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -2333,6 +2832,18 @@ static inline psa_status_t psa_driver_wrapper_aead_update_ad(
                     &operation->ctx.cc3xx_driver_ctx,
                     input, input_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_aead_update_ad(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_aead_update_ad(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        input, input_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -2379,6 +2890,20 @@ static inline psa_status_t psa_driver_wrapper_aead_update(
                     input, input_length, output, output_size,
                     output_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_aead_update(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length, output, output_size,
+                        output_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_aead_update(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        input, input_length, output, output_size,
+                        output_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -2430,6 +2955,20 @@ static inline psa_status_t psa_driver_wrapper_aead_finish(
                     ciphertext, ciphertext_size,
                     ciphertext_length, tag, tag_size, tag_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_aead_finish(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        ciphertext, ciphertext_size,
+                        ciphertext_length, tag, tag_size, tag_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_aead_finish(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        ciphertext, ciphertext_size,
+                        ciphertext_length, tag, tag_size, tag_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -2501,6 +3040,20 @@ static inline psa_status_t psa_driver_wrapper_aead_verify(
                     plaintext, plaintext_size,
                     plaintext_length, tag, tag_length ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_aead_verify(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        plaintext, plaintext_size,
+                        plaintext_length, tag, tag_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_aead_verify(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        plaintext, plaintext_size,
+                        plaintext_length, tag, tag_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -2538,6 +3091,16 @@ static inline psa_status_t psa_driver_wrapper_aead_abort(
             return( cc3xx_aead_abort(
                     &operation->ctx.cc3xx_driver_ctx ) );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_aead_abort(
+                        &operation->ctx.sli_se_transparent_ctx ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_aead_abort(
+                        &operation->ctx.sli_se_opaque_ctx ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
     }
 
@@ -2586,6 +3149,14 @@ static inline psa_status_t psa_driver_wrapper_mac_compute(
                 mac, mac_size, mac_length);
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_mac_compute(
+                        attributes, key_buffer, key_buffer_size, alg,
+                        input, input_length,
+                        mac, mac_size, mac_length );
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -2608,6 +3179,13 @@ static inline psa_status_t psa_driver_wrapper_mac_compute(
                 mac, mac_size, mac_length );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return ( sli_se_opaque_mac_compute(
+                        attributes, key_buffer, key_buffer_size, alg,
+                        input, input_length,
+                        mac, mac_size, mac_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -2666,6 +3244,19 @@ static inline psa_status_t psa_driver_wrapper_mac_sign_setup(
             operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
             return status;
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_mac_sign_setup(
+                &operation->ctx.sli_se_transparent_ctx,
+                attributes,
+                key_buffer, key_buffer_size,
+                alg );
+            /* Declared with fallback == true */
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -2696,6 +3287,17 @@ static inline psa_status_t psa_driver_wrapper_mac_sign_setup(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_mac_sign_setup(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        attributes,
+                        key_buffer, key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID;
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -2750,6 +3352,19 @@ static inline psa_status_t psa_driver_wrapper_mac_verify_setup(
             operation->id = PSA_CRYPTO_CC3XX_DRIVER_ID;
             return status;
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_mac_verify_setup(
+                &operation->ctx.sli_se_transparent_ctx,
+                attributes,
+                key_buffer, key_buffer_size,
+                alg );
+            /* Declared with fallback == true */
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID;
+
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 #if defined(MBEDTLS_PSA_BUILTIN_MAC)
             /* Fell through, meaning no accelerator supports this operation */
@@ -2780,6 +3395,17 @@ static inline psa_status_t psa_driver_wrapper_mac_verify_setup(
 
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_mac_verify_setup(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        attributes,
+                        key_buffer, key_buffer_size,
+                        alg );
+            if( status == PSA_SUCCESS )
+                operation->id = PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID;
+            return( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             /* Key is declared with a lifetime not known to us */
@@ -2821,6 +3447,18 @@ static inline psa_status_t psa_driver_wrapper_mac_update(
         case PSA_CRYPTO_CC3XX_DRIVER_ID:
             return(cc3xx_mac_update(&operation->ctx.cc3xx_driver_ctx, input, input_length));
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_mac_update(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        input, input_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_mac_update(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        input, input_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) input;
@@ -2860,6 +3498,18 @@ static inline psa_status_t psa_driver_wrapper_mac_sign_finish(
             return(cc3xx_mac_sign_finish(&operation->ctx.cc3xx_driver_ctx,
                         mac, mac_size, mac_length));
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_mac_sign_finish(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        mac, mac_size, mac_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_mac_sign_finish(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        mac, mac_size, mac_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) mac;
@@ -2900,6 +3550,18 @@ static inline psa_status_t psa_driver_wrapper_mac_verify_finish(
                         &operation->ctx.cc3xx_driver_ctx,
                         mac, mac_length));
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_mac_verify_finish(
+                        &operation->ctx.sli_se_transparent_ctx,
+                        mac, mac_length ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_mac_verify_finish(
+                        &operation->ctx.sli_se_opaque_ctx,
+                        mac, mac_length ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             (void) mac;
@@ -2931,6 +3593,16 @@ static inline psa_status_t psa_driver_wrapper_mac_abort(
         case PSA_CRYPTO_CC3XX_DRIVER_ID:
             return(cc3xx_mac_abort(&operation->ctx.cc3xx_driver_ctx));
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+        case PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID:
+            return( sli_se_transparent_mac_abort(
+                        &operation->ctx.sli_se_transparent_ctx ) );
+#endif
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID:
+            return( sli_se_opaque_mac_abort(
+                        &operation->ctx.sli_se_opaque_ctx ) );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
             return( PSA_ERROR_INVALID_ARGUMENT );
@@ -3136,6 +3808,20 @@ static inline psa_status_t psa_driver_wrapper_key_agreement(
                                           alg );
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_key_agreement( alg,
+                                                       attributes,
+                                                       key_buffer,
+                                                       key_buffer_size,
+                                                       peer_key,
+                                                       peer_key_length,
+                                                       shared_secret,
+                                                       shared_secret_size,
+                                                       shared_secret_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif
 #if defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED)
             if( PSA_KEY_TYPE_IS_ECC( psa_get_key_type(attributes) ) &&
                 PSA_ALG_IS_ECDH(alg) &&
@@ -3176,6 +3862,20 @@ static inline psa_status_t psa_driver_wrapper_key_agreement(
                         peer_key_length, shared_secret, shared_secret_size,
                         shared_secret_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TEST */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            status = sli_se_opaque_key_agreement( alg,
+                                                  attributes,
+                                                  key_buffer,
+                                                  key_buffer_size,
+                                                  peer_key,
+                                                  peer_key_length,
+                                                  shared_secret,
+                                                  shared_secret_size,
+                                                  shared_secret_length );
+            // Cannot have fallback for opaque drivers:
+            return ( status );
+#endif
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
 
         default:

--- a/library/psa_crypto_driver_wrappers_no_static.c
+++ b/library/psa_crypto_driver_wrappers_no_static.c
@@ -119,6 +119,7 @@ psa_status_t psa_driver_wrapper_get_key_buffer_size(
     psa_key_location_t location = PSA_KEY_LIFETIME_GET_LOCATION( psa_get_key_lifetime(attributes) );
     psa_key_type_t key_type = psa_get_key_type(attributes);
     size_t key_bits = psa_get_key_bits(attributes);
+    size_t buffer_size = 0;
 
     *key_buffer_size = 0;
     switch( location )
@@ -146,6 +147,14 @@ psa_status_t psa_driver_wrapper_get_key_buffer_size(
             return tfm_builtin_key_loader_get_key_buffer_size(psa_get_key_id(attributes),
                                                               key_buffer_size);
 #endif /* PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER */
+
+        case PSA_KEY_LOCATION_LOCAL_STORAGE:
+            buffer_size = PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits );
+            if( buffer_size == 0 ||
+                ( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) && buffer_size == 1 ) )
+                return( PSA_ERROR_NOT_SUPPORTED );
+            *key_buffer_size = buffer_size;
+            return( PSA_SUCCESS );
 
         default:
             (void)key_type;

--- a/library/psa_crypto_driver_wrappers_no_static.c
+++ b/library/psa_crypto_driver_wrappers_no_static.c
@@ -75,6 +75,19 @@
 #endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#endif
+#include "sli_psa_driver_features.h"
+#include "sli_cryptoacc_transparent_types.h"
+#include "sli_cryptoacc_transparent_functions.h"
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+#include "sli_cryptoacc_opaque_types.h"
+#include "sli_cryptoacc_opaque_functions.h"
+#endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
+
 /* END-driver headers */
 
 /* Auto-generated values depending on which drivers are registered.
@@ -98,6 +111,9 @@ enum {
     PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID,
 #endif
 #endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+    PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID,
+#endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 };
 
 /* END-driver id */
@@ -201,6 +217,13 @@ psa_status_t psa_driver_wrapper_get_key_buffer_size(
             return ( PSA_SUCCESS );
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SL_CRYPTOACC_OPAQUE:
+            buffer_size = sizeof(sli_cryptoacc_opaque_key_context_t);
+            *key_buffer_size = buffer_size;
+            return ( PSA_SUCCESS );
+#endif
+
         default:
             (void)key_type;
             (void)key_bits;
@@ -285,6 +308,18 @@ psa_status_t psa_driver_wrapper_export_public_key(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif // PSA_CRYPTO_DRIVER_SILABS_HSE
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
+            status = sli_cryptoacc_transparent_export_public_key( attributes,
+                                                                  key_buffer,
+                                                                  key_buffer_size,
+                                                                  data,
+                                                                  data_size,
+                                                                  data_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif // PSA_CRYPTO_DRIVER_SILABS_VSE
 
 #if (defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED) )
             status = p256_transparent_export_public_key
@@ -376,6 +411,14 @@ psa_status_t psa_driver_wrapper_get_builtin_key(
 #if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_BUILTIN_KEYS)
         case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
             return( sli_se_opaque_get_builtin_key(
+                        slot_number,
+                        attributes,
+                        key_buffer, key_buffer_size, key_buffer_length ) );
+#endif
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_VSE) && defined(SLI_PSA_DRIVER_FEATURE_BUILTIN_KEYS)
+        case PSA_KEY_LOCATION_SL_CRYPTOACC_OPAQUE:
+            return( sli_cryptoacc_opaque_get_builtin_key(
                         slot_number,
                         attributes,
                         key_buffer, key_buffer_size, key_buffer_length ) );

--- a/library/psa_crypto_driver_wrappers_no_static.c
+++ b/library/psa_crypto_driver_wrappers_no_static.c
@@ -62,6 +62,19 @@
 #include "cc3xx.h"
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#endif
+#include "sli_psa_driver_features.h"
+#include "sli_se_transparent_types.h"
+#include "sli_se_transparent_functions.h"
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+#include "sli_se_opaque_types.h"
+#include "sli_se_opaque_functions.h"
+#endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
+
 /* END-driver headers */
 
 /* Auto-generated values depending on which drivers are registered.
@@ -79,6 +92,12 @@ enum {
 #if defined(PSA_CRYPTO_DRIVER_CC3XX)
     PSA_CRYPTO_CC3XX_DRIVER_ID,
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+    PSA_CRYPTO_SILABS_HSE_TRANSPARENT_DRIVER_ID,
+#if defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+    PSA_CRYPTO_SILABS_HSE_OPAQUE_DRIVER_ID,
+#endif
+#endif /* PSA_CRYPTO_DRIVER_SILABS_HSE */
 };
 
 /* END-driver id */
@@ -120,6 +139,7 @@ psa_status_t psa_driver_wrapper_get_key_buffer_size(
     psa_key_type_t key_type = psa_get_key_type(attributes);
     size_t key_bits = psa_get_key_bits(attributes);
     size_t buffer_size = 0;
+    MBEDTLS_MAYBE_UNUSED size_t input_buffer_size = *key_buffer_size;
 
     *key_buffer_size = 0;
     switch( location )
@@ -155,6 +175,31 @@ psa_status_t psa_driver_wrapper_get_key_buffer_size(
                 return( PSA_ERROR_NOT_SUPPORTED );
             *key_buffer_size = buffer_size;
             return( PSA_SUCCESS );
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            buffer_size = PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits );
+            if( buffer_size == 0 ||
+                ( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) && buffer_size == 1 ) )
+                buffer_size = input_buffer_size;
+            // Remove public key format byte
+            if( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY( key_type ) ) {
+                buffer_size--;
+            }
+            // Compensate for word alignment demands
+            buffer_size = sli_se_word_align( buffer_size );
+            if( PSA_BITS_TO_BYTES( key_bits ) & 0x3 || PSA_BITS_TO_BYTES( key_bits ) == 0 ) {
+                if( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) ) {
+                    // Allocate extra word for public keys, since alignment constrains
+                    // May require that
+                    buffer_size += sizeof(uint32_t);
+                }
+            }
+            // Add wrapped context overhead
+            buffer_size += sizeof(sli_se_opaque_wrapped_key_context_t);
+            *key_buffer_size = buffer_size;
+            return ( PSA_SUCCESS );
+#endif
 
         default:
             (void)key_type;
@@ -229,6 +274,18 @@ psa_status_t psa_driver_wrapper_export_public_key(
             return( status );
 #endif /* PSA_CRYPTO_DRIVER_CC3XX */
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE)
+            status = sli_se_transparent_export_public_key( attributes,
+                                                           key_buffer,
+                                                           key_buffer_size,
+                                                           data,
+                                                           data_size,
+                                                           data_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif // PSA_CRYPTO_DRIVER_SILABS_HSE
+
 #if (defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED) )
             status = p256_transparent_export_public_key
                 (attributes,
@@ -268,6 +325,15 @@ psa_status_t psa_driver_wrapper_export_public_key(
         ));
 #endif
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return( sli_se_opaque_export_public_key( attributes,
+                                                     key_buffer,
+                                                     key_buffer_size,
+                                                     data,
+                                                     data_size,
+                                                     data_length ) );
+#endif
 
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:
@@ -306,6 +372,14 @@ psa_status_t psa_driver_wrapper_get_builtin_key(
                         attributes,
                         key_buffer, key_buffer_size, key_buffer_length ) );
 #endif /* PSA_CRYPTO_DRIVER_TFM_BUILTIN_KEY_LOADER */
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_HSE) && defined(SLI_PSA_DRIVER_FEATURE_BUILTIN_KEYS)
+        case PSA_KEY_LOCATION_SLI_SE_OPAQUE:
+            return( sli_se_opaque_get_builtin_key(
+                        slot_number,
+                        attributes,
+                        key_buffer, key_buffer_size, key_buffer_length ) );
+#endif
 
 #endif /* PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT */
         default:

--- a/library/psa_crypto_driver_wrappers_no_static.c
+++ b/library/psa_crypto_driver_wrappers_no_static.c
@@ -88,6 +88,17 @@
 #endif /* SLI_PSA_DRIVER_FEATURE_OPAQUE_KEYS */
 #endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
 
+#if defined(PSA_CRYPTO_DRIVER_SILABS_SI91X)
+#ifndef PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#define PSA_CRYPTO_ACCELERATOR_DRIVER_PRESENT
+#endif
+#include "sli_psa_driver_features.h"
+#include "sli_si91x_crypto_driver_functions.h"
+#if defined(SLI_PSA_DRIVER_FEATURE_WRAPPED_KEYS)
+#include "sl_si91x_psa_wrap.h"
+#endif /* Secure key storage driver **/
+#endif /* PSA_CRYPTO_DRIVER_SILABS_SI91X */
+
 /* END-driver headers */
 
 /* Auto-generated values depending on which drivers are registered.
@@ -114,6 +125,9 @@ enum {
 #if defined(PSA_CRYPTO_DRIVER_SILABS_VSE)
     PSA_CRYPTO_SILABS_VSE_TRANSPARENT_DRIVER_ID,
 #endif /* PSA_CRYPTO_DRIVER_SILABS_VSE */
+#if defined(PSA_CRYPTO_DRIVER_SILABS_SI91X)
+    PSA_CRYPTO_SILABS_SI91X_DRIVER_ID,
+#endif /* PSA_CRYPTO_DRIVER_SILABS_SI91X */
 };
 
 /* END-driver id */
@@ -224,6 +238,17 @@ psa_status_t psa_driver_wrapper_get_key_buffer_size(
             return ( PSA_SUCCESS );
 #endif
 
+#if defined(PSA_CRYPTO_CRIVER_SILABS_SI91X) && defined(SLI_PSA_DRIVER_FEATURE_WRAPPED_KEYS)
+        case PSA_KEY_VOLATILE_PERSISTENT_WRAPPED:
+          buffer_size = PSA_EXPORT_KEY_OUTPUT_SIZE( key_type, key_bits );
+          if( buffer_size == 0 ||
+              ( PSA_KEY_TYPE_IS_ECC_PUBLIC_KEY(key_type) && buffer_size == 1 ) )
+              return( PSA_ERROR_NOT_SUPPORTED );
+          *key_buffer_size = buffer_size;
+          return( PSA_SUCCESS );
+          break;
+#endif
+
         default:
             (void)key_type;
             (void)key_bits;
@@ -320,6 +345,18 @@ psa_status_t psa_driver_wrapper_export_public_key(
             if( status != PSA_ERROR_NOT_SUPPORTED )
                 return( status );
 #endif // PSA_CRYPTO_DRIVER_SILABS_VSE
+
+#if defined(PSA_CRYPTO_DRIVER_SILABS_SI91X) && defined(SLI_PSA_DRIVER_FEATURE_ECDH) 
+            status = sli_si91x_psa_export_public_key_ecdh( attributes,
+                                                           key_buffer,
+                                                           key_buffer_size,
+                                                           data,
+                                                           data_size,
+                                                           data_length );
+            /* Declared with fallback == true */
+            if( status != PSA_ERROR_NOT_SUPPORTED )
+                return( status );
+#endif // PSA_CRYPTO_DRIVER_SILABS_SI91X
 
 #if (defined(MBEDTLS_PSA_P256M_DRIVER_ENABLED) )
             status = p256_transparent_export_public_key


### PR DESCRIPTION
Initial port of hardware acceleration for Silicon Labs Series 2 and SiWx917 devices from SiSDK fork to Zephyr fork of mbed TLS.

Acceleration support is ported as-is, and has not yet been tested fully.